### PR TITLE
Issue #7: Fresh Data By Asking Propel 2 Times (php)

### DIFF
--- a/php/fresh-data-by-asking-propel-2-times.yml
+++ b/php/fresh-data-by-asking-propel-2-times.yml
@@ -1,0 +1,29 @@
+id: fresh-data-by-asking-propel-2-times
+title: 'Fresh Data By Asking Propel 2 Times'
+description: 'Yes, why not asking the database two times for a contact? Keeping it fresh!'
+labels:
+    - propel
+    - symfony
+    - retrieve
+    - duplicate
+    - denglisch
+    - denglish
+created_at: '2016-08-29T20:39:31Z'
+updated_at: '2016-08-29T20:39:59Z'
+issue:
+    title: 'Fresh Data By Asking Propel 2 Times'
+    url: 'https://github.com/codequote/submit/issues/7'
+    number: 7
+author:
+    username: florianpreusner
+    avatar: 'https://avatars.githubusercontent.com/u/728558?v=3'
+    profile_url: 'https://github.com/florianpreusner'
+language: php
+code: |
+    
+    if(is_object(KontaktPeer::retrieveByPK($request->getParameter('contact_id')))) {
+      $this->contact = KontaktPeer::retrieveByPK($request->getParameter('contact_id'));
+    } else {
+      $this->redirect('@contact_index');
+    }
+    


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Language        | php
| Description     | Yes, why not asking the database two times for a contact? Keeping it fresh!
| Search Keywords | propel, symfony, retrieve, duplicate, denglisch, denglish


```php
if(is_object(KontaktPeer::retrieveByPK($request->getParameter('contact_id')))) {
  $this->contact = KontaktPeer::retrieveByPK($request->getParameter('contact_id'));
} else {
  $this->redirect('@contact_index');
}
```
