### PR TITLE
Issue #19: Replaces with spaces the braces (php)

### DIFF
--- a/php/replaces-with-spaces-the-braces.yml
+++ b/php/replaces-with-spaces-the-braces.yml
@@ -1,0 +1,23 @@
+id: replaces-with-spaces-the-braces
+title: 'Replaces with spaces the braces'
+description: 'Replaces with spaces the braces in cases where braces in places cause stasis'
+labels:
+    - replace
+    - braces
+    - stasis
+created_at: '2016-10-06T14:27:25Z'
+updated_at: '2016-10-06T14:27:33Z'
+issue:
+    title: 'Replaces with spaces the braces'
+    url: 'https://github.com/codequote/submit/issues/19'
+    number: 19
+author:
+    username: florianpreusner
+    avatar: 'https://avatars.githubusercontent.com/u/728558?v=3'
+    profile_url: 'https://github.com/florianpreusner'
+language: php
+code: |
+    
+    // Replaces with spaces the braces in cases where braces in places cause stasis 
+    $str = str_replace(array("\{","\}")," ",$str);
+    


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Language        | php
| Description     | Replaces with spaces the braces in cases where braces in places cause stasis
| Search Keywords | replace, braces, stasis


```php
// Replaces with spaces the braces in cases where braces in places cause stasis 
$str = str_replace(array("\{","\}")," ",$str);
```
